### PR TITLE
fix: donate page UX paths

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -124,7 +124,7 @@ export default function LoginPage() {
       // redirect to donor-home after short delay
       setTimeout(() => {
         router.push("/donor-home");
-      }, 1500);
+      }, 1000);
     } catch (err: any) {
       let errorMessage = err.message || "An error occurred";
       if (err.code === "auth/user-not-found" || err.code === "auth/wrong-password" || err.code === "auth/invalid-credential") {

--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -19,6 +19,7 @@ export default function Navbar() {
   const handleLogout = async () => {
     try {
       await signOut(auth);
+      localStorage.clear();
       console.log("User logged out");
     } catch (err) {
       console.error("Error logging out:", err);


### PR DESCRIPTION
Fix:
1. Check for whether user is logged in when donating
2. if logged in, shows 1(select) and 2(confirm) only
3. if not logged in shows 1(select), 2(login), 3(confirm)
4. ensure that logging in after donating will keep the user logged in and count the amount
5. Prevent double logging in
6. After logging out, make sure that donate shows correct dialog
7. logging in, donate, then logging out, ensure that email is not remembered
8. Fix donate as displayName